### PR TITLE
Export the user’s environment variables for use with npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Some of the hooks are based on logic from https://github.com/kopurando/better-fa
 
 ## Release History
 
+* 1.2.1 Use user's environment variables with npm
 * 1.2.0 Avoid unnecessarily installing/rebuilding Node modules
 * 1.1.0 Cache Node modules between deploys
 * 1.0.0 Initial commit

--- a/source/.ebextensions/fix-npm.config
+++ b/source/.ebextensions/fix-npm.config
@@ -20,7 +20,17 @@ files:
       # And this lets us invoke npm more simply too.
       export PATH=/opt/elasticbeanstalk/node-install/node-v6.9.1-linux-x64/bin:$PATH
 
-      APP_STAGING_DIR=$(/opt/elasticbeanstalk/bin/get-config container -k app_staging_dir)
+      EB_APP_STAGING_DIR=$(/opt/elasticbeanstalk/bin/get-config container -k app_staging_dir)
+
+      # Export the user's environment variables for use with npm, both because
+      # EB does it https://gist.github.com/wearhere/de51bb799f5099cec0ed28b9d0eb3663#file-ebnode-py-L150
+      # as well as because we might need NPM_TOKEN.
+      eval $(node << EOS
+        var vars = JSON.parse('$(/opt/elasticbeanstalk/bin/get-config environment)');
+        console.log(Object.keys(vars)
+          .map((key) => \`export \${key}=\"\${vars[key]}\"\`)
+          .join('\n'));
+      EOS)
 
   "/opt/elasticbeanstalk/hooks/appdeploy/pre/45npm_downgrade.sh":
     mode: "000755"
@@ -54,7 +64,7 @@ files:
       if [ ! -d $CACHE_DIR ]; then
         mkdir $CACHE_DIR
       fi
-      ln -s $CACHE_DIR $APP_STAGING_DIR
+      ln -s $CACHE_DIR $EB_APP_STAGING_DIR
 
   "/opt/elasticbeanstalk/hooks/appdeploy/pre/50npm.sh":
     mode: "000755"
@@ -73,7 +83,7 @@ files:
       
       . /opt/elasticbeanstalk/env.vars
 
-      cd $APP_STAGING_DIR && npm install --production
+      cd $EB_APP_STAGING_DIR && npm install --production
 
   "/opt/elasticbeanstalk/hooks/appdeploy/pre/55npm_cleanup.sh":
     mode: "000755"
@@ -103,4 +113,4 @@ files:
       
       . /opt/elasticbeanstalk/env.vars
 
-      cd $APP_STAGING_DIR && npm rebuild --production
+      cd $EB_APP_STAGING_DIR && npm rebuild --production


### PR DESCRIPTION
Both because EB does it
https://gist.github.com/wearhere/de51bb799f5099cec0ed28b9d0eb3663#file-ebnode-py-L150
as well as because we might need NPM_TOKEN.