### PR TITLE
config for deployment with CodePipeline

### DIFF
--- a/source/.ebextensions/fix-npm.config
+++ b/source/.ebextensions/fix-npm.config
@@ -87,11 +87,18 @@ files:
       # need to be rebuilt. When the Node version changes, the configdeploy script
       # will rebuild.
       #
+      #
       # Note that this *overwrites* Elastic Beanstalk's default 50npm.sh script.
       
       . /opt/elasticbeanstalk/env.vars
 
-      cd $EB_APP_STAGING_DIR && npm install --production
+      cd $EB_APP_STAGING_DIR            
+
+      if [ -d node_modules ]; then # If there is an already existent node_modules in the deployed app (built by the AWS CodeBuild) 
+        npm_rebuild --production   # don't run npm install but run npm rebuild --production
+      else
+        npm install --production       # run npm install --production
+      fi
 
   "/opt/elasticbeanstalk/hooks/appdeploy/pre/55npm_cleanup.sh":
     mode: "000755"


### PR DESCRIPTION
This config is **compatible with normal deployments (works like the original script**).

The main difference is that before deploying, check if node_modules is already present and if so, only run `npm rebuild --production` instead of `npm install --production`.

The `node_modules` is already available in my case because the project is already built on CodePipeline and shipped with `node_modules` to the EB environment.

**The code pipeline should looks like this:**

1. Source from repo & branch
2. CodeBuild: 

   - Build with `npm install`
   - Output artifact should include `node_modules` folder.
3. CodeDeploy: 
   - Output artifact from the build (containing `node_modules`) will be deployed your EB environment.